### PR TITLE
update : 제네릭으로 선언한 부분 일부 수정

### DIFF
--- a/src/main/java/christmas/view/InputResult.java
+++ b/src/main/java/christmas/view/InputResult.java
@@ -1,14 +1,5 @@
 package christmas.view;
 
-public class InputResult<T> {
+public record InputResult(Object data) {
 
-    private final T data;
-
-    public InputResult(T data) {
-        this.data = data;
-    }
-
-    public T getData() {
-        return data;
-    }
 }

--- a/src/main/java/christmas/view/InputUtil.java
+++ b/src/main/java/christmas/view/InputUtil.java
@@ -1,7 +1,7 @@
 package christmas.view;
 
-public interface InputUtil<T> {
+public interface InputUtil {
 
-    T read();
+    String read();
 
 }

--- a/src/main/java/christmas/view/InputView.java
+++ b/src/main/java/christmas/view/InputView.java
@@ -3,26 +3,26 @@ package christmas.view;
 import christmas.view.validation.InputValidator;
 import java.util.function.Supplier;
 
-public class InputView<T> {
+public class InputView {
 
-    private final InputUtil<T> inputUtil;
+    private final InputUtil inputUtil;
     private final InputValidator<String> inputValidator;
 
-    public InputView(InputUtil<T> inputUtil, InputValidator<String> validator) {
+    public InputView(InputUtil inputUtil, InputValidator<String> validator) {
         this.inputUtil = inputUtil;
         this.inputValidator = validator;
     }
 
-    public InputResult<T> read() {
+    public InputResult read() {
         System.out.println("입력하세요.");
         return repeat(inputUtil::read, inputValidator);
     }
 
-    private InputResult<T> repeat(Supplier<T> input, InputValidator<String> validator) {
+    private InputResult repeat(Supplier<String> input, InputValidator<String> validator) {
         try {
-            T inputData = input.get();
-            validator.validate((String) inputData);
-            return new InputResult<>(inputData);
+            String inputData = input.get();
+            validator.validate(inputData);
+            return new InputResult(inputData);
         } catch (IllegalArgumentException e) {
             System.out.println(e.getMessage());
             return repeat(input, validator);


### PR DESCRIPTION
## 🧑‍💻 작업 내용
> 작업한 내용 정리
- `InputUtil` 인터페이스의 `read` 추상메소드 리턴 타입 `String` 으로 변경
- `InputResult` 의 객체 제네릭에서 `Object` 타입으로 변경
   - `class` 에서 `record` 로 변경
- `InputView` 의 제네릭 제거

<br>

## 🚀 이슈
> 발생 이슈 없을시 생략 가능





<br>
