### PR TITLE
fix : 매뉴 타입상수 선언 순서변경

### DIFF
--- a/src/main/java/christmas/model/domain/constant/Type.java
+++ b/src/main/java/christmas/model/domain/constant/Type.java
@@ -2,9 +2,9 @@ package christmas.model.domain.constant;
 
 public enum Type {
 
-    MAIN,
     APPETIZER,
-    DESSERT,
-    BEVERAGE
+    MAIN,
+    BEVERAGE,
+    DESSERT
 
 }


### PR DESCRIPTION
## 🧑‍💻 작업 내용
> 작업한 내용 정리
- 매뉴 타입상수 선언 순서변경
   - `에피타이저` - `메인`  - `음료` - `디저트` 순으로 출력하기 위해 변경


<br>

## 🚀 이슈
> 발생 이슈 없을시 생략 가능
- 구현 기능 정리 README 에 수정사항 반영 필요 


<br>
